### PR TITLE
fix: Correct certificate providers translation

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -263,7 +263,7 @@ export default function Home() {
                 <CardTitle className="text-lg">{t.certificatesTitles.googleAnalytics}</CardTitle>
               </CardHeader>
               <CardContent>
-                <p className="text-sm text-muted-foreground mb-2">Google - Coursera</p>
+                <p className="text-sm text-muted-foreground mb-2">{t.certificatesProviders.googleAnalytics}</p>
                 <div className="flex items-center gap-2 text-xs text-muted-foreground mb-2">
                   <span>100 h</span>
                   <span>•</span>
@@ -280,7 +280,7 @@ export default function Home() {
                 <CardTitle className="text-lg">{t.certificatesTitles.dryNeedling}</CardTitle>
               </CardHeader>
               <CardContent>
-                <p className="text-sm text-muted-foreground mb-2">Fisiofocus</p>
+                <p className="text-sm text-muted-foreground mb-2">{t.certificatesProviders.dryNeedling}</p>
                 <div className="flex items-center gap-2 text-xs text-muted-foreground">
                   <span>60 h</span>
                   <span>•</span>
@@ -294,7 +294,7 @@ export default function Home() {
                 <CardTitle className="text-lg">{t.certificatesTitles.shoulder}</CardTitle>
               </CardHeader>
               <CardContent>
-                <p className="text-sm text-muted-foreground mb-2">Gesundheitskonsortium von Anoia</p>
+                <p className="text-sm text-muted-foreground mb-2">{t.certificatesProviders.shoulder}</p>
                 <div className="flex items-center gap-2 text-xs text-muted-foreground">
                   <span>5 h</span>
                   <span>•</span>

--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -60,6 +60,11 @@ export const translations = {
       dryNeedling: "Punción Seca y Tratamiento Conservador del Síndrome del Dolor Miofascial",
       shoulder: "Abordaje del Dolor de Hombro con el Manguito de los Rotadores"
     },
+    certificatesProviders: {
+      googleAnalytics: "Google - Coursera",
+      dryNeedling: "Fisiofocus",
+      shoulder: "Consorci Sanitari de l'Anoia"
+    },
     certificatesNotes: {
       allEnglish: "100% en inglés",
     },
@@ -153,6 +158,11 @@ export const translations = {
       googleAnalytics: "Google Data Analytics",
       dryNeedling: "Dry Needling und konservative Behandlung des myofaszialen Schmerzsyndroms",
       shoulder: "Rotatorenmanschette – Ansatz bei Schulterschmerzen"
+    },
+    certificatesProviders: {
+      googleAnalytics: "Google - Coursera",
+      dryNeedling: "Fisiofocus",
+      shoulder: "Gesundheitskonsortium von Anoia"
     },
     certificatesNotes: {
       allEnglish: "100% auf Englisch",


### PR DESCRIPTION
- Add certificatesProviders section to translations
- Fix hardcoded certificate provider names to use dynamic translations
- Spanish: 'Consorci Sanitari de l'Anoia' for shoulder certificate
- German: 'Gesundheitskonsortium von Anoia' for shoulder certificate
- Update Google Analytics and Dry Needling providers to use translations
- Ensure proper language switching for all certificate providers